### PR TITLE
feat: update strapi packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,17 +13,15 @@
     "jquery": "^3.7.1",
     "knex": "^0.21.18",
     "sqlite3": "5.0.0",
-    "strapi": "^3.6.11",
-    "strapi-admin": "3.6.11",
-    "strapi-connector-bookshelf": "3.6.11",
-    "strapi-plugin-content-manager": "3.6.11",
-    "strapi-plugin-content-type-builder": "3.6.11",
-    "strapi-plugin-email": "3.6.11",
-    "strapi-plugin-upload": "3.6.11",
-    "strapi-plugin-users-permissions": "3.6.11",
-    "strapi-provider-upload-local": "3.6.11",
-    "strapi-provider-email-sendmail": "3.6.11",
-    "strapi-utils": "3.6.11",
+    "@strapi/strapi": "^4.0.0",
+    "@strapi/plugin-content-manager": "^4.0.0",
+    "@strapi/plugin-content-type-builder": "^4.0.0",
+    "@strapi/plugin-email": "^4.0.0",
+    "@strapi/plugin-upload": "^4.0.0",
+    "@strapi/plugin-users-permissions": "^4.0.0",
+    "@strapi/provider-email-sendmail": "^4.0.0",
+    "@strapi/provider-upload-local": "^4.0.0",
+    "@strapi/utils": "^4.0.0",
     "yup": "^1.7.0"
   },
   "author": {
@@ -33,8 +31,8 @@
     "uuid": "12d8a977-539a-46ec-823b-b9732525861c"
   },
   "engines": {
-    "node": ">=10.16.0 <=14.x.x",
-    "npm": "^6.0.0"
+    "node": ">=14.19.0",
+    "npm": ">=6.0.0"
   },
   "license": "MIT",
   "packageManager": "yarn@3.2.1"


### PR DESCRIPTION
## Summary
- migrate Strapi dependencies to `@strapi/*`
- require Node >=14.19 and modern npm

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `yarn install` *(fails: tunneling socket could not be established, statusCode=403)*
- `npm run build` *(fails: You need to run strapi build in a Strapi project)*

------
https://chatgpt.com/codex/tasks/task_e_688ff9f46eb0832694857ebaf257dfa8